### PR TITLE
Configuring all cookies expiration to Session

### DIFF
--- a/static/js/client_hooks.js
+++ b/static/js/client_hooks.js
@@ -17,6 +17,17 @@ exports.documentReady = function (hook_name, args, cb) {
             }
         }, options))
     }
+
+    const pad_utils = require("ep_etherpad-lite/static/js/pad_utils");
+
+    // wrap js-cookie's setter for configuring all cookies expiration to Session
+    const originalCookiesSetter = pad_utils.Cookies['set'];
+    pad_utils.Cookies['set'] = function(key, value, attributes = {}) {
+      // destructure attributes to remove expires property
+      const { expires, ...attr } = attributes;
+      return originalCookiesSetter(key, value, attr);
+    }
+
     return cb();
 }
 


### PR DESCRIPTION
Since we started flushing Etherpad's data from Redis client's have been experiencing
problems while loading pads. This issue is caused by persistent cookies from previous
pads.

This change wraps the original js-cookie's setter keeping all original attributes but
`expires`, which when not available defines a current session only cookie.

Closes #1