### PR TITLE
Add white background in export; set default filename

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,7 +4,9 @@
             "name": "bbb_hooks",
             "hooks": {
                 "eejsBlock_loading": "ep_bigbluebutton_patches/index:eejsBlock_loading",
-                "eejsBlock_importColumn": "ep_bigbluebutton_patches/index:eejsBlock_importColumn"
+                "eejsBlock_importColumn": "ep_bigbluebutton_patches/index:eejsBlock_importColumn",
+                "stylesForExport": "ep_bigbluebutton_patches/index:stylesForExport",
+                "exportFileName": "ep_bigbluebutton_patches/index:exportFileName"
             },
             "client_hooks": {
                 "documentReady": "ep_bigbluebutton_patches/static/js/client_hooks:documentReady",

--- a/index.js
+++ b/index.js
@@ -1,13 +1,23 @@
 const eejs = require('ep_etherpad-lite/node/eejs/');
 
-// replace the loading block with a nice spinner
+// Replaces the loading block with a nice spinner
 exports.eejsBlock_loading =  function (hook_name, args, cb) {
     args.content = eejs.require('ep_bigbluebutton_patches/templates/spinner.html')
     return cb();
 }
 
-// remove import UI
+// Removes import UI
 exports.eejsBlock_importColumn = function (hook_name, args, cb) {
     args.content = ''
     return cb();
+}
+
+// Sets exported file background to white
+exports.stylesForExport = function(hook, padId, cb) {
+    cb('body{background-color:white}');
+}
+
+// Sets export default file name
+exports.exportFileName = function(hook, padId, cb) {
+    cb('Shared_Notes');
 }


### PR DESCRIPTION
Since the adoption of Tldraw in 2.6, the whiteboard started to support transparency in file uploads.

One of these transparent presentatation comes from the "Move notes to whiteboard" feature. When users switched to dark mode, the text became unreadable.

This PR adds a default white background on all exports to match the previous behavior. Additionally, it sets the name of the generated file to match the one used in the meeting when moving notes to the presentation area.

![dark-mode-fix](https://user-images.githubusercontent.com/33319791/185098051-91409778-dd1e-44b8-a2f5-3202d0c1c00d.png)

Closes:
[#15535](https://github.com/bigbluebutton/bigbluebutton/issues/15535)
[#14342](https://github.com/bigbluebutton/bigbluebutton/issues/14342)
#4 

