### PR TITLE
Add config option for CORS headers to support cluster proxy setup

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -6,7 +6,9 @@
                 "eejsBlock_loading": "ep_bigbluebutton_patches/index:eejsBlock_loading",
                 "eejsBlock_importColumn": "ep_bigbluebutton_patches/index:eejsBlock_importColumn",
                 "stylesForExport": "ep_bigbluebutton_patches/index:stylesForExport",
-                "exportFileName": "ep_bigbluebutton_patches/index:exportFileName"
+                "exportFileName": "ep_bigbluebutton_patches/index:exportFileName",
+                "expressConfigure": "ep_bigbluebutton_patches/index:expressConfigure",
+                "exportConvert": "ep_bigbluebutton_patches/index:exportConvert"
             },
             "client_hooks": {
                 "documentReady": "ep_bigbluebutton_patches/static/js/client_hooks:documentReady",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const eejs = require('ep_etherpad-lite/node/eejs/');
+const fs = require('fs');
+const OVERRIDE_CONFIG_PATH = '/etc/bigbluebutton/etherpad.json';
+let override_config = null;
 
 // Replaces the loading block with a nice spinner
 exports.eejsBlock_loading =  function (hook_name, args, cb) {
@@ -21,3 +24,36 @@ exports.stylesForExport = function(hook, padId, cb) {
 exports.exportFileName = function(hook, padId, cb) {
     cb('Shared_Notes');
 }
+
+function addAccessControlHeader(req, res) {
+    override_config.cluster_proxies.forEach((proxy_url) => {
+        if (req.headers.origin == proxy_url) {
+            res.header('Access-Control-Allow-Origin', proxy_url);
+	    res.header('Access-Control-Allow-Credentials', 'true');
+        }
+    });
+}
+
+// load config file on startup
+exports.expressConfigure = (hookName, args) => {
+    if (fs.existsSync(OVERRIDE_CONFIG_PATH)) {
+        override_config = JSON.parse(fs.readFileSync(OVERRIDE_CONFIG_PATH));
+        if (override_config['cluster_proxies']) {
+            args.app.use(function(req, res, next) {
+                addAccessControlHeader(req, res);
+                next();
+            });
+        }
+    }
+};
+
+// pdf conversion is asynchronous. There is a custom callback to allow request
+// modification.
+// The Send notes to whiteboard function downloads the slides as PDF to the
+// browser and uploads them to BBB again. For this scenario a CORS request is
+// necessary to etherpad. This is allowed here.
+exports.exportConvert = (hookname, args) => {
+    if (override_config && override_config['cluster_proxies']) {
+        addAccessControlHeader(args.req, args.res);
+    }
+};


### PR DESCRIPTION
Cluster proxy setup required correct CORS headers to move notes to whiteboard. This patch adds an option to configure it. To configure it add a file `/etc/bigbluebutton/etherpad.json` with similar content:

```json
{
	"cluster_proxies": [
		"https://bbb-proxy.example.org"
	]
}
```

related to https://github.com/bigbluebutton/bigbluebutton/pull/15457
related to https://github.com/bigbluebutton/bigbluebutton/pull/15753